### PR TITLE
Support Missing Optionals

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,7 @@
 plugins {
-    kotlin("jvm") version "1.9.20" apply false
+    val kotlinVersion = "1.9.20"
+
+    kotlin("jvm") version kotlinVersion apply false
+    kotlin("plugin.serialization") version kotlinVersion apply false
 }
+

--- a/dynamap-lib/build.gradle.kts
+++ b/dynamap-lib/build.gradle.kts
@@ -3,6 +3,7 @@ val dynamoDbVersion: String = "1.0.69"
 
 plugins {
     kotlin("jvm")
+    kotlin("plugin.serialization")
 
     id("maven-publish")
 
@@ -21,7 +22,16 @@ repositories {
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$serializationCoreVersion")
     implementation("aws.sdk.kotlin:dynamodb:$dynamoDbVersion")
+    testImplementation(kotlin("test-junit5"))
 }
+
+tasks.named<Test>("test") {
+    useJUnitPlatform()
+    testLogging {
+        events("passed", "skipped", "failed")
+    }
+}
+
 
 publishing {
     repositories {

--- a/dynamap-lib/src/main/kotlin/com/codanbaru/serialization/DynamoMapCompositeDecoder.kt
+++ b/dynamap-lib/src/main/kotlin/com/codanbaru/serialization/DynamoMapCompositeDecoder.kt
@@ -26,23 +26,20 @@ internal class DynamoMapCompositeDecoder(
     }
 
     private var currentIndex = 0
-    private val keys = `object`.keys.sorted()
     override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
-        if (currentIndex >= keys.size || currentIndex >= descriptor.elementsCount) return CompositeDecoder.DECODE_DONE
-
-        val element = `object`[propertyAtIndex(descriptor, currentIndex)]
-        if (element == null && descriptor.isElementOptional(currentIndex)) {
-            currentIndex += 1
-            return currentIndex // skip this element
-        }
-
-        // if (currentIndex >= descriptor.elementsCount) return CompositeDecoder.UNKNOWN_NAME
-        //
-        // try { descriptor.getElementName(currentIndex) } catch (throwable: Throwable) { return CompositeDecoder.UNKNOWN_NAME }
+        if (currentIndex >= descriptor.elementsCount) return CompositeDecoder.DECODE_DONE
 
         val currentIndex = this.currentIndex
         this.currentIndex += 1
-        return currentIndex
+
+        // Check if the element we try to decode is present,
+        // is element is not present, try to decode next element index.
+        val element = try { elementAtIndex(descriptor, currentIndex) } catch (throwable: Throwable) { null }
+        if (element == null) {
+            return decodeElementIndex(descriptor)
+        } else {
+            return currentIndex
+        }
     }
 
     private fun annotationsAtIndex(descriptor: SerialDescriptor, index: Int): List<Annotation> =
@@ -59,7 +56,9 @@ internal class DynamoMapCompositeDecoder(
 
         var element = `object`[propertyName]
         if (element == null && configuration.evaluateUndefinedAttributesAsNullAttribute) {
-            element = AttributeValue.Null(true)
+            if (!descriptor.isElementOptional(index)) {
+                element = AttributeValue.Null(true)
+            }
         }
 
         return element ?: throw DynamapSerializationException.UnexpectedUndefined(property.subproperty(propertyName))

--- a/dynamap-lib/src/main/kotlin/com/codanbaru/serialization/DynamoMapCompositeDecoder.kt
+++ b/dynamap-lib/src/main/kotlin/com/codanbaru/serialization/DynamoMapCompositeDecoder.kt
@@ -30,6 +30,12 @@ internal class DynamoMapCompositeDecoder(
     override fun decodeElementIndex(descriptor: SerialDescriptor): Int {
         if (currentIndex >= keys.size || currentIndex >= descriptor.elementsCount) return CompositeDecoder.DECODE_DONE
 
+        val element = `object`[propertyAtIndex(descriptor, currentIndex)]
+        if (element == null && descriptor.isElementOptional(currentIndex)) {
+            currentIndex += 1
+            return currentIndex // skip this element
+        }
+
         // if (currentIndex >= descriptor.elementsCount) return CompositeDecoder.UNKNOWN_NAME
         //
         // try { descriptor.getElementName(currentIndex) } catch (throwable: Throwable) { return CompositeDecoder.UNKNOWN_NAME }

--- a/dynamap-lib/src/test/kotlin/com/codanbaru/serialization/DynamapTest.kt
+++ b/dynamap-lib/src/test/kotlin/com/codanbaru/serialization/DynamapTest.kt
@@ -1,0 +1,135 @@
+package com.codanbaru.serialization
+
+import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
+import com.codanbaru.serialization.format.decodeFromItem
+import com.codanbaru.serialization.format.encodeToItem
+import org.junit.jupiter.api.assertAll
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DynamapTest {
+    val dynamap = Dynamap {
+        classDiscriminator = "_type"
+    }
+
+    @Test
+    fun `only primitives`() {
+        assertCodec(
+            Fixtures.Primitives(
+                string = "string",
+                char = 'c',
+                short = 0,
+                int = 1,
+                long = 2,
+                float = 3.0F,
+                double = 4.0,
+            ),
+            mapOf(
+                "string" to AttributeValue.S("string"),
+                "char" to AttributeValue.N("c"),
+                "short" to AttributeValue.N("0"),
+                "int" to AttributeValue.N("1"),
+                "long" to AttributeValue.N("2"),
+                "float" to AttributeValue.N("3.0"),
+                "double" to AttributeValue.N("4.0"),
+            )
+        )
+    }
+
+    @Test
+    fun `optionals with all values set`() {
+        assertCodec(
+            Fixtures.Optionals(
+                a = 1,
+                b = 2,
+                c = 3
+            ),
+            mapOf(
+                "a" to AttributeValue.N("1"),
+                "b" to AttributeValue.N("2"),
+                "c" to AttributeValue.N("3"),
+            )
+        )
+    }
+
+    @Test
+    fun `optionals with no optionals set`() {
+        assertAll(
+            {
+                assertCodec(
+                    Fixtures.Optionals(
+                        a = 0
+                    ),
+                    mapOf(
+                        "a" to AttributeValue.N("0"),
+                        "b" to AttributeValue.N("1"),
+                        "c" to AttributeValue.N("2"),
+                    )
+                )
+            },
+            {
+                assertDecode(
+                    Fixtures.Optionals(a = 0),
+                    mapOf("a" to AttributeValue.N("0")),
+                )
+            }
+        )
+    }
+
+    @Test
+    fun `optionals with middle optionals not set`() {
+        assertAll(
+            {
+                assertCodec(
+                    Fixtures.Optionals(
+                        a = 0,
+                        c = 3,
+                    ),
+                    mapOf(
+                        "a" to AttributeValue.N("0"),
+                        "b" to AttributeValue.N("1"),
+                        "c" to AttributeValue.N("3"),
+                    )
+                )
+            },
+            {
+                assertDecode(
+                    Fixtures.Optionals(a = 0, c = 3),
+                    mapOf(
+                        "a" to AttributeValue.N("0"),
+                        "c" to AttributeValue.N("3")
+                    ),
+                )
+            }
+        )
+    }
+
+    @Test
+    fun `polymorphic`() {
+        assertAll(
+            {
+                assertCodec(
+                    Fixtures.Polymorphic(type = Fixtures.Polymorphic.Type.A(1)),
+                    mapOf(
+                        "type" to AttributeValue.M(mapOf(
+                            "_type" to AttributeValue.S("a"),
+                            "a" to AttributeValue.N("1"),
+                        ))
+                    )
+                )
+            }
+        )
+    }
+
+    inline fun <reified T>assertCodec(expectedObj: T, expectedItem: Map<String, AttributeValue>) {
+        assertAll(
+            { assertEquals(expectedItem, dynamap.encodeToItem(expectedObj), "encoding to tiem") },
+            { assertDecode(expectedObj, expectedItem) },
+            { assertEquals(expectedObj, dynamap.decodeFromItem(dynamap.encodeToItem(expectedObj))) },
+        )
+    }
+
+    inline fun <reified T>assertDecode(expectedObj: T, actualItem: Map<String, AttributeValue>) {
+        assertEquals(expectedObj, dynamap.decodeFromItem(actualItem), "decoding from item")
+    }
+}

--- a/dynamap-lib/src/test/kotlin/com/codanbaru/serialization/Fixtures.kt
+++ b/dynamap-lib/src/test/kotlin/com/codanbaru/serialization/Fixtures.kt
@@ -1,0 +1,41 @@
+package com.codanbaru.serialization
+
+import aws.sdk.kotlin.services.dynamodb.model.AttributeValue
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+object Fixtures {
+    @Serializable
+    data class Primitives(
+        val string: String,
+        val char: Char,
+        val short: Short,
+        val int: Int,
+        val long: Long,
+        val float: Float,
+        val double: Double,
+    )
+
+    @Serializable
+    data class Optionals(
+        val a: Int,
+        val b: Int = 1,
+        val c: Int = 2
+    )
+
+    @Serializable
+    data class Polymorphic(val type: Type) {
+
+        @Serializable
+        sealed interface Type {
+            @Serializable
+            @SerialName("a")
+            data class A(val a: Int): Type
+
+            @Serializable
+            @SerialName("b")
+            data class B(val b: Int): Type
+        }
+
+    }
+}


### PR DESCRIPTION
- Adds some basic tests to cover simple use cases
- Fixed issue where when decoding from an item with missing fields that could be optional didn't actually decode but rather through an error or defaulted to null

Fixes #2 